### PR TITLE
Playground UI: declutter controls with Program/Graphics/Advanced tabs

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -41,6 +41,7 @@ const state = {
   frameOkCount: 0,
   frameErrCount: 0,
   frameMsAvg: 0,
+  activeControlsTab: 'program',
 };
 
 void start();
@@ -96,37 +97,51 @@ function renderLayout() {
       <div id="sidebar-splitter" class="splitter splitter-v" title="Resize sidebar"></div>
       <section class="workspace">
         <div class="controls">
-          <button id="btn-demo">Graphics Demo</button>
-          <label class="frame-control">Preset
-            <select id="gfx-preset">
-              <option value="demo">inline demo</option>
-              <option value="random_walk">random_walk</option>
-              <option value="barnsly_fern">barnsly_fern</option>
-              <option value="game_of_life">game_of_life</option>
-            </select>
-          </label>
-          <button id="btn-run-preset">Run Preset</button>
-          <button id="btn-check">Check</button>
-          <button id="btn-run">Run</button>
-          <button id="btn-stop-loop">Stop Loop</button>
-          <label class="fuel-control">Fuel
-            <input id="fuel" type="range" min="10000" max="50000000" step="10000" value="${DEFAULT_FUEL}" />
-            <span id="fuel-label"></span>
-          </label>
-          <label class="frame-control">FPS
-            <input id="frame-fps" type="number" min="1" max="120" step="1" value="30" />
-          </label>
-          <label class="frame-control">Frame Fuel
-            <input id="frame-fuel" type="number" min="1000" max="50000000" step="1000" value="1000000" />
-          </label>
-          <label class="frame-control">
-            <input id="frame-log" type="checkbox" />
-            Frame Log
-          </label>
-          <label class="fuel-unlimited ${localUnlimited ? '' : 'fuel-unlimited-disabled'}" title="Only available on localhost">
-            <input id="fuel-unlimited" type="checkbox" ${localUnlimited ? '' : 'disabled'} />
-            Unlimited
-          </label>
+          <div class="controls-primary">
+            <button id="btn-check">Check</button>
+            <button id="btn-run">Run</button>
+            <button id="btn-stop-loop">Stop Loop</button>
+            <span class="mode-pill">Bytecode Safe Mode</span>
+          </div>
+          <div class="controls-tabs" role="tablist" aria-label="Control groups">
+            <button type="button" class="ctrl-tab is-active" data-tab="program" aria-selected="true">Program</button>
+            <button type="button" class="ctrl-tab" data-tab="graphics" aria-selected="false">Graphics</button>
+            <button type="button" class="ctrl-tab" data-tab="advanced" aria-selected="false">Advanced</button>
+          </div>
+          <div class="controls-panel is-active" data-panel="program">
+            <label class="fuel-control">Fuel
+              <input id="fuel" type="range" min="10000" max="50000000" step="10000" value="${DEFAULT_FUEL}" />
+              <span id="fuel-label"></span>
+            </label>
+            <label class="fuel-unlimited ${localUnlimited ? '' : 'fuel-unlimited-disabled'}" title="Only available on localhost">
+              <input id="fuel-unlimited" type="checkbox" ${localUnlimited ? '' : 'disabled'} />
+              Unlimited
+            </label>
+          </div>
+          <div class="controls-panel" data-panel="graphics">
+            <button id="btn-demo">Graphics Demo</button>
+            <label class="frame-control">Preset
+              <select id="gfx-preset">
+                <option value="demo">inline demo</option>
+                <option value="random_walk">random_walk</option>
+                <option value="barnsly_fern">barnsly_fern</option>
+                <option value="game_of_life">game_of_life</option>
+              </select>
+            </label>
+            <button id="btn-run-preset">Run Preset</button>
+            <label class="frame-control">FPS
+              <input id="frame-fps" type="number" min="1" max="120" step="1" value="30" />
+            </label>
+          </div>
+          <div class="controls-panel" data-panel="advanced">
+            <label class="frame-control">Frame Fuel
+              <input id="frame-fuel" type="number" min="1000" max="50000000" step="1000" value="1000000" />
+            </label>
+            <label class="frame-control">
+              <input id="frame-log" type="checkbox" />
+              Frame Log
+            </label>
+          </div>
         </div>
         <div id="editor" class="editor"></div>
         <div id="gfx-host" class="gfx-host hidden">
@@ -206,10 +221,28 @@ function renderLayout() {
     stopS2DLoop();
     setStatus('Graphics loop stopped.');
   });
+  for (const tabBtn of document.querySelectorAll('.ctrl-tab')) {
+    tabBtn.addEventListener('click', () => {
+      setActiveControlsTab(tabBtn.dataset.tab || 'program');
+    });
+  }
+  setActiveControlsTab('program');
 
   populateLibraryTrees();
   installBrowserHostBridge();
   setupResizers();
+}
+
+function setActiveControlsTab(tab) {
+  state.activeControlsTab = tab;
+  for (const tabBtn of document.querySelectorAll('.ctrl-tab')) {
+    const isActive = tabBtn.dataset.tab === tab;
+    tabBtn.classList.toggle('is-active', isActive);
+    tabBtn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  }
+  for (const panel of document.querySelectorAll('.controls-panel')) {
+    panel.classList.toggle('is-active', panel.dataset.panel === tab);
+  }
 }
 
 function isLocalHost() {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -140,10 +140,63 @@ body {
 
 .controls {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
   padding: 10px;
   border-bottom: 1px solid #263357;
+}
+
+.controls-primary {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mode-pill {
+  margin-left: auto;
+  border: 1px solid #335085;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 12px;
+  color: #b6c3ee;
+  background: #162443;
+}
+
+.controls-tabs {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ctrl-tab {
+  border-radius: 999px;
+  background: #142343;
+  color: #b7c4ef;
+  padding: 6px 12px;
+}
+
+.ctrl-tab.is-active {
+  border-color: #4ad395;
+  color: #d9ffe8;
+  background: #19314c;
+}
+
+.controls-panel {
+  width: 100%;
+  display: none;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid #263357;
+  border-radius: 8px;
+  background: #111b34;
+}
+
+.controls-panel.is-active {
+  display: flex;
 }
 
 button {
@@ -160,7 +213,6 @@ button:hover {
 }
 
 .fuel-control {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -199,6 +251,10 @@ button:hover {
   background: #142343;
   border-radius: 5px;
   padding: 4px 6px;
+}
+
+.fuel-control input[type='range'] {
+  width: min(360px, 55vw);
 }
 
 .fuel-unlimited-disabled {
@@ -282,6 +338,15 @@ button:hover {
   .workspace {
     grid-template-rows: auto minmax(220px, 1fr) auto auto 10px minmax(120px, 220px);
     height: auto;
+  }
+
+  .mode-pill {
+    margin-left: 0;
+  }
+
+  .fuel-control input[type='range'] {
+    width: 100%;
+    min-width: 220px;
   }
 }
 


### PR DESCRIPTION
## Summary
- decluttered the Playground control bar into a two-row layout
- kept core actions always visible: Check, Run, Stop Loop
- added tabbed control groups: Program, Graphics, Advanced
- moved graphics-specific controls into Graphics tab
- moved frame-specific tuning controls into Advanced tab
- retained all existing control IDs and behavior, only reorganized layout and styles

## UX Outcome
- less visual clutter in the default view
- clearer separation between normal run controls and graphics/perf knobs
- mobile layout remains responsive with tabbed panels

## Validation
- local build attempt reached wasm step; blocked by missing local Rust target `wasm32-unknown-unknown`
- JS/CSS patch applied cleanly and committed
