### PR TITLE
Playground: hide non-.f files in stdlib sidebar

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -836,6 +836,9 @@ async function populateLibraryTrees() {
   const manifest = await fetch('./runtime/manifest.json').then((r) => r.json());
 
   for (const rel of manifest.stdlibFiles) {
+    if (!rel.endsWith('.f')) {
+      continue;
+    }
     const li = document.createElement('li');
     const btn = document.createElement('button');
     btn.type = 'button';


### PR DESCRIPTION
## Summary
- filter stdlib sidebar entries to show only `.f` source files

## Why
Avoid showing non-source artifacts (e.g. `README.md`, `LICENSE`) in the Playground stdlib file picker.
