### PR TITLE
CI: prefetch Rust deps for offline bytecode validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Prefetch Rust dependencies for offline VM tests
+        run: cargo fetch --manifest-path funk_vm/Cargo.toml --locked
+
       - name: Install Python dependencies
         run: |
           python -m venv venv_3.11
@@ -198,6 +201,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Prefetch Rust dependencies for offline VM tests
+        run: cargo fetch --manifest-path funk_vm/Cargo.toml --locked
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
Summary: prefetch Cargo deps for funk_vm before offline bytecode validation and full-validation release-check. Reason: fresh runners fail cargo test --offline with missing serde_json unless crates are fetched first. Verification: reviewed failing run logs and validated cargo fetch command locally.