### PR TITLE
Fix remaining CI gate failures (warning gate + bench report)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ bench-fp-triad: build-root
 	FUNK_BUILD_ROOT="$(BUILD_ROOT)" ./venv_3.11/bin/python ./scripts/benchmark_fp_triad_compare.py --runs 5 --backend cpp20
 
 bench-report: build-root
+	cd ./funk_vm && cargo build --release --offline
 	FUNK_BUILD_ROOT="$(BUILD_ROOT)" ./venv_3.11/bin/python ./benchmarks/generate_report.py --runs $(BENCH_RUNS) --warmup $(BENCH_WARMUP)
 
 bench-all: bench-report


### PR DESCRIPTION
Summary:
- update funk submodule to include lib_funky PR #6 fixes for Wextra/Werror warnings in c_model_opt
- ensure bench-report builds funk_vm release binary before running generate_report

Validation:
- FUNK_EXTRA_CXXFLAGS="-Wall -Wextra -Werror" make tests-fast
- make bench-report BENCH_RUNS=1 BENCH_WARMUP=0