### PR TITLE
Close graphics overlay outside Graphics tab and add X button

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -25,6 +25,7 @@ const state = {
   sourcePath: '/workspace/main.f',
   gfxWrapEl: null,
   gfxCanvasEl: null,
+  gfxCloseEl: null,
   gfxCtx: null,
   gfxColor: 'rgb(0,255,0)',
   gfxUserCtx: null,
@@ -168,6 +169,10 @@ function renderLayout() {
         </div>
         <div id="editor" class="editor"></div>
         <div id="gfx-host" class="gfx-host hidden">
+          <div class="gfx-host-head">
+            <span>Graphics Output</span>
+            <button id="btn-gfx-close" type="button" class="gfx-close-btn" aria-label="Close graphics output">X</button>
+          </div>
           <canvas id="gfx-canvas"></canvas>
         </div>
         <div class="meta">
@@ -203,6 +208,7 @@ function renderLayout() {
   state.buildInfoEl = document.getElementById('build-info');
   state.gfxWrapEl = document.getElementById('gfx-host');
   state.gfxCanvasEl = document.getElementById('gfx-canvas');
+  state.gfxCloseEl = document.getElementById('btn-gfx-close');
   state.frameFpsEl = document.getElementById('frame-fps');
   state.frameFuelEl = document.getElementById('frame-fuel');
   state.frameLogEl = document.getElementById('frame-log');
@@ -244,6 +250,9 @@ function renderLayout() {
     stopS2DLoop();
     setStatus('Graphics loop stopped.');
   });
+  state.gfxCloseEl?.addEventListener('click', () => {
+    closeGraphicsOutput(true);
+  });
   for (const tabBtn of document.querySelectorAll('.ctrl-tab')) {
     tabBtn.addEventListener('click', () => {
       setActiveControlsTab(tabBtn.dataset.tab || 'program');
@@ -276,6 +285,19 @@ function setActiveControlsTab(tab) {
   }
   for (const panel of document.querySelectorAll('.controls-panel')) {
     panel.classList.toggle('is-active', panel.dataset.panel === tab);
+  }
+  if (tab !== 'graphics') {
+    closeGraphicsOutput(false);
+  }
+}
+
+function closeGraphicsOutput(announce) {
+  stopS2DLoop();
+  if (state.gfxWrapEl) {
+    state.gfxWrapEl.classList.add('hidden');
+  }
+  if (announce) {
+    setStatus('Graphics output closed.');
   }
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -301,6 +301,28 @@ button:hover {
   background: #0b1226;
 }
 
+.gfx-host-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.gfx-close-btn {
+  border: 1px solid #335085;
+  background: #162443;
+  color: #b7c4ef;
+  padding: 2px 8px;
+  border-radius: 6px;
+  line-height: 1.2;
+}
+
+.gfx-close-btn:hover {
+  background: #223764;
+}
+
 .gfx-host canvas {
   display: block;
   max-width: 100%;


### PR DESCRIPTION
Summary:\n- close graphics output and stop render loop when switching away from the Graphics tab\n- add an explicit X close button in the graphics output panel\n- style the graphics panel header and close button\n\nValidation:\n- node --check web/src/main.js