### PR TITLE
Fix output panel resizing/clamping behavior

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -320,6 +320,12 @@ function setupResizers() {
   if (!layout || !workspace || !sidebarSplitter || !outputSplitter) {
     return;
   }
+  const clampOutputHeight = () => {
+    const current = parseFloat(getComputedStyle(workspace).getPropertyValue('--output-height')) || 160;
+    const min = 100;
+    const max = Math.max(min, Math.floor(workspace.clientHeight * 0.6));
+    workspace.style.setProperty('--output-height', `${Math.min(max, Math.max(min, current))}px`);
+  };
 
   sidebarSplitter.addEventListener('pointerdown', (event) => {
     if (window.matchMedia('(max-width: 960px)').matches) {
@@ -352,7 +358,7 @@ function setupResizers() {
     const onMove = (moveEvent) => {
       const next = startHeight - (moveEvent.clientY - startY);
       const min = 100;
-      const max = Math.max(min, Math.floor(window.innerHeight * 0.6));
+      const max = Math.max(min, Math.floor(workspace.clientHeight * 0.6));
       workspace.style.setProperty('--output-height', `${Math.min(max, Math.max(min, next))}px`);
     };
     const onUp = () => {
@@ -363,6 +369,8 @@ function setupResizers() {
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
   });
+  window.addEventListener('resize', clampOutputHeight);
+  clampOutputHeight();
 }
 
 async function loadBuildInfo() {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -363,7 +363,8 @@ button:disabled {
 
 .output {
   margin: 0;
-  min-height: 100px;
+  min-height: 0;
+  height: 100%;
   overflow: auto;
   padding: 10px;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
Summary:\n- make output pane fill its grid track (height 100%, min-height 0)\n- clamp output splitter against workspace height instead of window height\n- re-clamp output height on window resize to avoid stale oversized values\n\nValidation:\n- node --check web/src/main.js