### PR TITLE
Stabilize output panel rendering with wrapper shell

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -184,7 +184,9 @@ function renderLayout() {
           <div id="status"></div>
         </div>
         <div id="output-splitter" class="splitter splitter-h" title="Resize output"></div>
-        <pre id="output" class="output"></pre>
+        <div class="output-shell">
+          <pre id="output" class="output"></pre>
+        </div>
       </section>
     </main>
   `;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -361,6 +361,14 @@ button:disabled {
   display: none;
 }
 
+.output-shell {
+  min-height: 0;
+  height: 100%;
+  background: #0c1327;
+  border-radius: 0 0 10px 10px;
+  overflow: hidden;
+}
+
 .output {
   margin: 0;
   min-height: 0;
@@ -368,8 +376,7 @@ button:disabled {
   overflow: auto;
   padding: 10px;
   font-family: 'IBM Plex Mono', monospace;
-  background: #0c1327;
-  border-radius: 0 0 10px 10px;
+  background: transparent;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
Summary:\n- wrap output pre in a dedicated output-shell container\n- move panel background/border radius to shell for stable rendering\n- keep pre as scrollable transparent content area\n\nWhy:\nFixes visual regression where output panel looked split/misaligned after resizing.\n\nValidation:\n- node --check web/src/main.js