### PR TITLE
Harden GitHub Actions workflows with SHA pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - stable_2026
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -19,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout funk
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -38,7 +41,7 @@ jobs:
           sudo apt-get install -y clang
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -67,12 +70,12 @@ jobs:
 
     steps:
       - name: Checkout funk
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -85,12 +88,12 @@ jobs:
           sudo apt-get install -y clang
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Prefetch Rust dependencies for offline VM tests
         run: cargo fetch --manifest-path funk_vm/Cargo.toml --locked
@@ -111,7 +114,7 @@ jobs:
 
       - name: Upload bytecode failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: bytecode-failure-artifacts
           path: |
@@ -126,12 +129,12 @@ jobs:
 
     steps:
       - name: Checkout funk
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -144,7 +147,7 @@ jobs:
           sudo apt-get install -y clang
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -167,7 +170,7 @@ jobs:
 
       - name: Upload warning gate log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: warning-gate-log
           path: warning-gate.log
@@ -180,12 +183,12 @@ jobs:
 
     steps:
       - name: Checkout funk
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -198,12 +201,12 @@ jobs:
           sudo apt-get install -y clang
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Prefetch Rust dependencies for offline VM tests
         run: cargo fetch --manifest-path funk_vm/Cargo.toml --locked
@@ -224,7 +227,7 @@ jobs:
 
       - name: Upload benchmark smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: benchmark-smoke-artifacts
           path: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -33,13 +33,13 @@ jobs:
           submodules: recursive
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 
@@ -64,10 +64,10 @@ jobs:
         run: touch web/dist/.nojekyll
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: web/dist
 
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -7,17 +7,20 @@ on:
       - main
       - stable_2026
 
+permissions:
+  contents: read
+
 jobs:
   web-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: diegovalverde/funky_example_files
           ref: 77bd37bfbdf64a72df2ae70a35812affb3806d80
@@ -25,13 +28,13 @@ jobs:
           submodules: recursive
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Summary
- pin all GitHub Action uses references in CI workflows to commit SHAs
- add explicit least-privilege `permissions: contents: read` to CI and web-build workflows
- keep existing Pages permissions model, only pin action refs

## Files changed
- .github/workflows/ci.yml
- .github/workflows/pages.yml
- .github/workflows/web-build.yml

## Validation
- make sync-submodules
- make tests-fast
- make examples-smoke
- make test-bytecode
- make release-check

All commands passed locally.
